### PR TITLE
Fix search clear icon and editing contact.

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ INSERT INTO contact(last_name, first_name, address, mobile_number, email_address
 ```bash
 $ cd addressbook-javafx-hibernate-mysql
 $ ./mvnw clean package
-$ java -jar java -jar ./target/addressbook-javafx-hibernate-mysql-0.0.2.jar
+$ java -jar java -jar ./target/addressbook-javafx-hibernate-mysql-0.0.3.jar
 ```
 
 - Windows
@@ -45,7 +45,7 @@ $ java -jar java -jar ./target/addressbook-javafx-hibernate-mysql-0.0.2.jar
 ```bash
 > cd addressbook-javafx-hibernate-mysql
 > .\mvnw clean package
-> java -jar java -jar .\target\addressbook-javafx-hibernate-mysql-0.0.2.jar
+> java -jar java -jar .\target\addressbook-javafx-hibernate-mysql-0.0.3.jar
 ```
 
 ## Note

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.julianjupiter</groupId>
     <artifactId>addressbook-javafx-hibernate-mysql</artifactId>
-    <version>0.0.2</version>
+    <version>0.0.3</version>
     <packaging>jar</packaging>
 
     <description>Address book application written in JavaFX with Hibernate and MySQL.</description>

--- a/src/main/java/com/julianjupiter/addressbook/controller/EditContactController.java
+++ b/src/main/java/com/julianjupiter/addressbook/controller/EditContactController.java
@@ -7,6 +7,7 @@ import javafx.scene.control.TextField;
 import javafx.scene.paint.Color;
 
 import java.net.URL;
+import java.time.OffsetDateTime;
 import java.util.Map;
 import java.util.ResourceBundle;
 
@@ -52,12 +53,15 @@ public class EditContactController implements Controller, Initializable {
     }
 
     public ContactProperty contactProperty() {
-        return this.contactProperty
+        return new ContactProperty()
+                .setId(this.contactProperty.getId())
                 .setFirstName(firstNameTextField.getText())
                 .setLastName(lastNameTextField.getText())
                 .setAddress(addressTextField.getText())
                 .setMobileNumber(mobileNumberTextField.getText())
-                .setEmailAddress(emailAddressTextField.getText());
+                .setEmailAddress(emailAddressTextField.getText())
+                .setCreatedAt(this.contactProperty.getCreatedAt())
+                .setUpdatedAt(OffsetDateTime.now());
     }
 
     public void validation(Map<String, String> violations) {

--- a/src/main/java/com/julianjupiter/addressbook/controller/MainController.java
+++ b/src/main/java/com/julianjupiter/addressbook/controller/MainController.java
@@ -304,8 +304,7 @@ public class MainController implements Controller, Initializable {
 
             this.saveFontIcon.setOnMouseClicked(null);
             this.saveFontIcon.setOnMouseClicked(mouseEvent1 -> {
-                ContactProperty contactProperty = editContactController.contactProperty()
-                        .setUpdatedAt(OffsetDateTime.now());
+                ContactProperty contactProperty = editContactController.contactProperty();
                 Set<ConstraintViolation<ContactProperty>> contactConstraintViolations = this.validator.validate(contactProperty);
                 if (!contactConstraintViolations.isEmpty()) {
                     var violations = contactConstraintViolations.stream()
@@ -326,7 +325,9 @@ public class MainController implements Controller, Initializable {
                             .setFirstName(updatedContactProperty.getFirstName())
                             .setAddress(updatedContactProperty.getAddress())
                             .setMobileNumber(updatedContactProperty.getMobileNumber())
-                            .setEmailAddress(updatedContactProperty.getEmailAddress());
+                            .setEmailAddress(updatedContactProperty.getEmailAddress())
+                            .setCreatedAt(updatedContactProperty.getCreatedAt())
+                            .setUpdatedAt(updatedContactProperty.getUpdatedAt());
                     this.viewContact(this.selectedContactProperty);
                 }
             });

--- a/src/main/java/com/julianjupiter/addressbook/controller/MainController.java
+++ b/src/main/java/com/julianjupiter/addressbook/controller/MainController.java
@@ -17,6 +17,7 @@ import javafx.scene.control.Label;
 import javafx.scene.control.TableColumn;
 import javafx.scene.control.TableView;
 import javafx.scene.control.TextField;
+import javafx.scene.input.MouseEvent;
 import javafx.scene.layout.AnchorPane;
 import javafx.scene.layout.BorderPane;
 import javafx.scene.paint.Paint;
@@ -180,10 +181,9 @@ public class MainController implements Controller, Initializable {
         this.searchContactTextField.setOnKeyReleased(keyEvent -> {
             var name = this.searchContactTextField.getText().trim();
             this.contactPropertiesObservable.setAll(this.findContacts(name));
-
-            Node xButton = this.searchContactTextField.lookup(".right-button-graphic");
+            Node xButton = this.searchContactTextField.lookup(".right-button");
             if(xButton != null) {
-                xButton.setOnMousePressed(mouseEvent -> {
+                xButton.addEventHandler(MouseEvent.MOUSE_PRESSED, mouseEvent -> {
                     this.contactPropertiesObservable.setAll(this.findContacts(null));
                 });
             }

--- a/src/main/java/com/julianjupiter/addressbook/controller/MainController.java
+++ b/src/main/java/com/julianjupiter/addressbook/controller/MainController.java
@@ -242,8 +242,7 @@ public class MainController implements Controller, Initializable {
 
             this.saveFontIcon.setOnMouseClicked(null);
             this.saveFontIcon.setOnMouseClicked(mouseEvent1 -> {
-                ContactProperty contactProperty = newContactController.contactProperty()
-                        .setCreatedAt(OffsetDateTime.now());
+                ContactProperty contactProperty = newContactController.contactProperty();
                 Set<ConstraintViolation<ContactProperty>> contactConstraintViolations = this.validator.validate(contactProperty);
                 if (!contactConstraintViolations.isEmpty()) {
                     var violations = contactConstraintViolations.stream()

--- a/src/main/java/com/julianjupiter/addressbook/controller/NewContactController.java
+++ b/src/main/java/com/julianjupiter/addressbook/controller/NewContactController.java
@@ -7,6 +7,7 @@ import javafx.scene.control.TextField;
 import javafx.scene.paint.Color;
 
 import java.net.URL;
+import java.time.OffsetDateTime;
 import java.util.Map;
 import java.util.ResourceBundle;
 
@@ -34,7 +35,7 @@ public class NewContactController implements Controller, Initializable {
 
     @Override
     public void initialize(URL url, ResourceBundle resourceBundle) {
-
+        
     }
 
     public ContactProperty contactProperty() {
@@ -43,7 +44,8 @@ public class NewContactController implements Controller, Initializable {
                 .setLastName(lastNameTextField.getText())
                 .setAddress(addressTextField.getText())
                 .setMobileNumber(mobileNumberTextField.getText())
-                .setEmailAddress(emailAddressTextField.getText());
+                .setEmailAddress(emailAddressTextField.getText())
+                .setCreatedAt(OffsetDateTime.now());
     }
 
     public void validation(Map<String, String> violations) {

--- a/src/main/java/com/julianjupiter/addressbook/util/View.java
+++ b/src/main/java/com/julianjupiter/addressbook/util/View.java
@@ -23,7 +23,7 @@ public class View<T extends Controller, U extends Parent> {
 
     public static <T extends Controller, U extends Parent> View<T, U> of(Class<T> controllerClass, Class<U> componentClass) {
         try {
-            return new View(controllerClass, null);
+            return new View<>(controllerClass, null);
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
@@ -31,7 +31,7 @@ public class View<T extends Controller, U extends Parent> {
 
     public static <T extends Controller, U extends Parent> View<T, U> of(Class<T> controllerClass, Class<U> componentClass, ResourceBundle resourceBundle) {
         try {
-            return new View(controllerClass, resourceBundle);
+            return new View<>(controllerClass, resourceBundle);
         } catch (IOException e) {
             throw new RuntimeException(e);
         }


### PR DESCRIPTION
- There is part of clear icon which does not have mouse event handler that when clicked/pressed it causes not to fetch contacts from the database
- In editing contact, even if there is error and without database save operation, values for table columns first name and last name are being displayed.